### PR TITLE
Tensorflow: Add patch to fix gettid naming conflict in grpc.

### DIFF
--- a/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
+++ b/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 0000000000..30f1d7b252
 --- /dev/null
 +++ b/third_party/systemlibs/0001-Fix-gettid-naming-conflict.patch
-@@ -0,0 +1,37 @@
+@@ -0,1 +1,37 @@
 +From de6255941a5e1c2fb2d50e57f84e38c09f45023d Mon Sep 17 00:00:00 2001
 +From: Juanli Shen <juanlishen@google.com>
 +Date: Fri, 23 Aug 2019 08:46:09 -0700
@@ -32,12 +32,12 @@ index 0000000000..30f1d7b252
 +@@ -40,7 +40,9 @@
 + #include <time.h>
 + #include <unistd.h>
-+ 
++
 +-static long gettid(void) { return syscall(__NR_gettid); }
 ++// Not naming it as gettid() to avoid duplicate declarations when complied with
 ++// GCC 9.1.
 ++static long local_gettid(void) { return syscall(__NR_gettid); }
-+ 
++
 + void gpr_log(const char* file, int line, gpr_log_severity severity,
 +	       const char* format, ...) {
 +@@ -70,7 +72,7 @@ void gpr_default_log(gpr_log_func_args* args) {
@@ -46,7 +46,7 @@ index 0000000000..30f1d7b252
 +   static __thread long tid = 0;
 +-  if (tid == 0) tid = gettid();
 ++  if (tid == 0) tid = local_gettid();
-+ 
++
 +   timer = static_cast<time_t>(now.tv_sec);
 +   final_slash = strrchr(args->file, '/');
 +

--- a/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
+++ b/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
@@ -1,0 +1,58 @@
+diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
+index 788eca2f67..8a37fe5643 100755
+--- a/tensorflow/workspace.bzl
++++ b/tensorflow/workspace.bzl
+@@ -465,6 +475,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
+         sha256 = "1aa84387232dda273ea8fdfe722622084f72c16f7b84bfc519ac7759b71cdc91",
+         strip_prefix = "grpc-69b6c047bc767b4d80e7af4d00ccb7c45b683dae",
+         system_build_file = clean_dep("//third_party/systemlibs:grpc.BUILD"),
++        patch_file = clean_dep("//third_party/systemlibs:0001-Fix-gettid-naming-conflict.patch"),
+         urls = [
+             "https://mirror.bazel.build/github.com/grpc/grpc/archive/69b6c047bc767b4d80e7af4d00ccb7c45b683dae.tar.gz",
+             "https://github.com/grpc/grpc/archive/69b6c047bc767b4d80e7af4d00ccb7c45b683dae.tar.gz",
+diff --git a/third_party/systemlibs/0001-Fix-gettid-naming-conflict.patch b/third_party/systemlibs/0001-Fix-gettid-naming-conflict.patch
+new file mode 100644
+index 0000000000..30f1d7b252
+--- /dev/null
++++ b/third_party/systemlibs/0001-Fix-gettid-naming-conflict.patch
+@@ -0,0 +1,37 @@
++From de6255941a5e1c2fb2d50e57f84e38c09f45023d Mon Sep 17 00:00:00 2001
++From: Juanli Shen <juanlishen@google.com>
++Date: Fri, 23 Aug 2019 08:46:09 -0700
++Subject: [PATCH] Fix gettid() naming conflict
++
++---
++ src/core/lib/gpr/log_linux.cc | 6 ++++--
++ 1 file changed, 4 insertions(+), 2 deletions(-)
++
++diff --git a/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
++index 561276f0c20..81026e5689b 100644
++--- a/src/core/lib/gpr/log_linux.cc
+++++ b/src/core/lib/gpr/log_linux.cc
++@@ -40,7 +40,9 @@
++ #include <time.h>
++ #include <unistd.h>
++ 
++-static long gettid(void) { return syscall(__NR_gettid); }
+++// Not naming it as gettid() to avoid duplicate declarations when complied with
+++// GCC 9.1.
+++static long local_gettid(void) { return syscall(__NR_gettid); }
++ 
++ void gpr_log(const char* file, int line, gpr_log_severity severity,
++	       const char* format, ...) {
++@@ -70,7 +72,7 @@ void gpr_default_log(gpr_log_func_args* args) {
++   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
++   struct tm tm;
++   static __thread long tid = 0;
++-  if (tid == 0) tid = gettid();
+++  if (tid == 0) tid = local_gettid();
++ 
++   timer = static_cast<time_t>(now.tv_sec);
++   final_slash = strrchr(args->file, '/');
++
++-- 
++2.17.1
++
+-- 
+2.17.1
+

--- a/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
+++ b/recipes-framework/tensorflow/files/0001-Fix-gettid-naming-conflict.patch
@@ -2,7 +2,7 @@ diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
 index 788eca2f67..8a37fe5643 100755
 --- a/tensorflow/workspace.bzl
 +++ b/tensorflow/workspace.bzl
-@@ -465,6 +475,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
+@@ -475,6 +485,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
          sha256 = "1aa84387232dda273ea8fdfe722622084f72c16f7b84bfc519ac7759b71cdc91",
          strip_prefix = "grpc-69b6c047bc767b4d80e7af4d00ccb7c45b683dae",
          system_build_file = clean_dep("//third_party/systemlibs:grpc.BUILD"),
@@ -15,7 +15,7 @@ new file mode 100644
 index 0000000000..30f1d7b252
 --- /dev/null
 +++ b/third_party/systemlibs/0001-Fix-gettid-naming-conflict.patch
-@@ -0,1 +1,37 @@
+@@ -0,0 +1,37 @@
 +From de6255941a5e1c2fb2d50e57f84e38c09f45023d Mon Sep 17 00:00:00 2001
 +From: Juanli Shen <juanlishen@google.com>
 +Date: Fri, 23 Aug 2019 08:46:09 -0700

--- a/recipes-framework/tensorflow/tensorflow_1.13.0.bb
+++ b/recipes-framework/tensorflow/tensorflow_1.13.0.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/tensorflow/tensorflow.git;branch=r1.13 \
            file://0001-label_image.lite-tweak-default-model-location.patch \
            file://0001-use-local-bazel-to-workaround-bazel-paralle-issue.patch \
            file://0001-CheckFeatureOrDie-use-warning-to-avoid-die.patch \
+           file://0001-Fix-gettid-naming-conflict.patch \
            file://BUILD \
            file://BUILD.yocto_compiler \
            file://CROSSTOOL.tpl \


### PR DESCRIPTION
This pulls in an upstream patch from `grpc` to fix `error: ambiguating new declaration of 'long int gettid()'` when building `tensorflow`.